### PR TITLE
passing null to setcookie param is deprecated

### DIFF
--- a/src/Storage/Cookie.php
+++ b/src/Storage/Cookie.php
@@ -40,7 +40,7 @@ class Cookie implements StorageInterface {
         if (!headers_sent()) {
             // we do not throw an exception for now when headers already sent to not break the application
             // but could do later to make users aware there is an error
-            setcookie($name, $value, time() + (86400 * 365 * 2), $path = '/', $domain = null, $secure = null, $httpOnly = true);
+            setcookie($name, $value, time() + (86400 * 365 * 2), $path = '/', $domain = '', $secure = false, $httpOnly = true);
         }
     }
 


### PR DESCRIPTION
### Description:
This change is to resolve a deprecation warning that happens when running on php8.1
```
A PHP Error was encountered
Severity: 8192

Message:  setcookie(): Passing null to parameter #5 ($domain) of type string is deprecated
Message: setcookie(): Passing null to parameter #6 ($secure) of type bool is deprecated

Filename: Storage/Cookie.php

Line Number: 43

Backtrace:

File: /vendor/innocraft/php-experiments/src/Storage/Cookie.php
Line: 43
```

### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
